### PR TITLE
Formatted spaces in the Heap.java source file

### DIFF
--- a/3. Algorithms_and_Data_Structures_in_Java/8. Introduction_-_Heap /Java Heaps/src/Heap.java
+++ b/3. Algorithms_and_Data_Structures_in_Java/8. Introduction_-_Heap /Java Heaps/src/Heap.java
@@ -277,7 +277,6 @@ public class Heap {
 	}
 
 	public static void main(String[] args) {
-		
 		Heap newHeap = new Heap(7);
 
 		newHeap.generateFilledArray(90);


### PR DESCRIPTION
This pull request includes a small change to the `Heap.java` file. The change removes an unnecessary blank line in the `main` method.